### PR TITLE
uninitialized constant FaradayApiResponseParser::InternalError を修正

### DIFF
--- a/lib/faraday_api_response_parser/parse_api_response.rb
+++ b/lib/faraday_api_response_parser/parse_api_response.rb
@@ -40,7 +40,7 @@ module FaradayApiResponseParser
         when 404
           raise FaradayApiResponseParser::NotFoundError
         when 500
-          raise FaradayApiResponseParser::InternalError
+          raise FaradayApiResponseParser::InternalServerError
         when 500
           raise FaradayApiResponseParser::ServiceUnavailableError
         end


### PR DESCRIPTION
InternalError を InternalServerErrorに修正
